### PR TITLE
BUILD-10765 Important: Update SonarSource/gh-action_release to v6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,6 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v6
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@4ac0f4304e2858f8144ac48037bb135b5fdac1ad # v6.7.1
     with:
       slackChannel: squad-ide-private

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,6 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@c52861bb0e5dd564187f3fd74e048f20aef0f761 # 6.5.0
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v6
     with:
       slackChannel: squad-ide-private


### PR DESCRIPTION
**Important:** Update GitHub Actions to compliant versions.

- `.github/workflows/release.yml`: `release` `c52861bb0e5dd564187f3fd74e048f20aef0f761` → `v6`

See: https://discuss.sonarsource.com/t/action-required-update-your-github-actions-cache-release-and-releasability-before-31-04-2026/23899